### PR TITLE
Update to work with V 0.4.0 + slight reorganizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ import os
 fn main() {
 	width := 500
 	height := 400
-	rgba := [][4]byte{len: width * height, init: [byte(255), 0, 0, 255]!}
+	rgba := [][4]u8{len: width * height, init: [u8(255), 0, 0, 255]!}
 	metadata := vqoi.ImageMetadata{u32(width), u32(height), .rgba, .srgb}
 	image := vqoi.Image{rgba, metadata}
 	data := vqoi.encode(image)
-	os.write_file('hello.qoi', data.bytestr()) ?
+	os.write_file('hello.qoi', data.bytestr()) !
 
-	decoded_image := vqoi.decode(data) ?
+	decoded_image := vqoi.decode(data) !
 	assert decoded_image == image
 }
 ```

--- a/example/test_qoi.v
+++ b/example/test_qoi.v
@@ -15,9 +15,9 @@ fn main() {
 	}
 }
 
-fn try_file(filename string) ? {
-	data := (os.read_file(filename) ?).bytes()
-	image := vqoi.decode(data) ?
+fn try_file(filename string) ! {
+	data := (os.read_file(filename) or { return err }).bytes()
+	image := vqoi.decode(data) or { return err }
 	encoded := vqoi.encode(image)
 	if data != encoded {
 		return error('does not match')

--- a/example/test_qoi.v
+++ b/example/test_qoi.v
@@ -8,10 +8,10 @@ import vqoi
 fn main() {
 	for arg in os.args[1..] {
 		try_file(arg) or {
-			println('[FAILED ] $arg: $err')
+			println('[FAILED ] ${arg}: ${err}')
 			continue
 		}
-		println('[SUCCESS] $arg')
+		println('[SUCCESS] ${arg}')
 	}
 }
 

--- a/example/test_qoi.v
+++ b/example/test_qoi.v
@@ -1,5 +1,7 @@
 // tested with https://qoiformat.org/qoi_test_images.zip
 
+module main
+
 import os
 import vqoi
 

--- a/example/test_qoi.v
+++ b/example/test_qoi.v
@@ -16,10 +16,11 @@ fn main() {
 }
 
 fn try_file(filename string) ! {
-	data := (os.read_file(filename) or { return err }).bytes()
-	image := vqoi.decode(data) or { return err }
+	data := (os.read_file(filename)!).bytes()
+	image := vqoi.decode(data)!
 	encoded := vqoi.encode(image)
 	if data != encoded {
 		return error('does not match')
 	}
+	// assert data == encoded
 }

--- a/example/test_qoi.v
+++ b/example/test_qoi.v
@@ -22,5 +22,4 @@ fn try_file(filename string) ! {
 	if data != encoded {
 		return error('does not match')
 	}
-	// assert data == encoded
 }

--- a/src/color_hash.v
+++ b/src/color_hash.v
@@ -1,5 +1,5 @@
 module vqoi
 
-fn color_hash(rgba [4]byte) byte {
+fn color_hash(rgba [4]u8) u8 {
 	return (rgba[0] * 3 + rgba[1] * 5 + rgba[2] * 7 + rgba[3] * 11) & 0x3f
 }

--- a/src/decoder.v
+++ b/src/decoder.v
@@ -14,12 +14,12 @@ pub fn decode(data []u8) !Image {
 	mut last_pixel := [u8(0), 0, 0, 255]!
 
 	for offset < data.len - 8 && pixels.len < total_pixels {
-		current_u8 := data[offset]
+		current_byte := data[offset]
 		mut new_pixel := [4]u8{}
 		$if vqoi_debug ? {
-			eprintln('decode: pos: $offset / $data.len, value: $current_u8')
+			eprintln('decode: pos: ${offset} / ${data.len}, value: ${current_byte}')
 		}
-		if current_u8 == 0b1111_1110 { // QOI_OP_RGB
+		if current_byte == 0b1111_1110 { // QOI_OP_RGB
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_RGB')
 			}
@@ -28,7 +28,7 @@ pub fn decode(data []u8) !Image {
 			new_pixel[2] = data[offset + 3]
 			new_pixel[3] = last_pixel[3]
 			offset += 4
-		} else if current_u8 == 0b1111_1111 { // QOI_OP_RGBA
+		} else if current_byte == 0b1111_1111 { // QOI_OP_RGBA
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_RGBA')
 			}
@@ -37,39 +37,39 @@ pub fn decode(data []u8) !Image {
 			new_pixel[2] = data[offset + 3]
 			new_pixel[3] = data[offset + 4]
 			offset += 5
-		} else if current_u8 >> 6 == 0b00 { // QOI_OP_INDEX
+		} else if current_byte >> 6 == 0b00 { // QOI_OP_INDEX
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_INDEX')
 			}
-			new_pixel = array[current_u8]
+			new_pixel = array[current_byte]
 			offset++
-		} else if current_u8 >> 6 == 0b01 { // QOI_OP_DIFF
+		} else if current_byte >> 6 == 0b01 { // QOI_OP_DIFF
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_DIFF')
 			}
-			new_pixel[0] = last_pixel[0] + (current_u8 >> 4 & 0b0000_0011) - 2
-			new_pixel[1] = last_pixel[1] + (current_u8 >> 2 & 0b0000_0011) - 2
-			new_pixel[2] = last_pixel[2] + (current_u8 & 0b11) - 2
+			new_pixel[0] = last_pixel[0] + (current_byte >> 4 & 0b0000_0011) - 2
+			new_pixel[1] = last_pixel[1] + (current_byte >> 2 & 0b0000_0011) - 2
+			new_pixel[2] = last_pixel[2] + (current_byte & 0b11) - 2
 			new_pixel[3] = last_pixel[3]
 			offset++
-		} else if current_u8 >> 6 == 0b10 { // QOI_OP_LUME
+		} else if current_byte >> 6 == 0b10 { // QOI_OP_LUME
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_LUME')
 			}
 			next_u8 := data[offset + 1]
-			vg := (current_u8 & 0x3f) - 32
+			vg := (current_byte & 0x3f) - 32
 			new_pixel[0] = last_pixel[0] + vg - 8 + (next_u8 >> 4 & 0b0000_1111)
 			new_pixel[1] = last_pixel[1] + vg
 			new_pixel[2] = last_pixel[2] + vg - 8 + (next_u8 & 0b0000_1111)
 			new_pixel[3] = last_pixel[3]
 			offset += 2
-		} else if current_u8 >> 6 == 0b11 { // QOI_OP_RUN
+		} else if current_byte >> 6 == 0b11 { // QOI_OP_RUN
 			$if vqoi_debug ? {
-				eprintln('decode: QOI_OP_RUN len=${1 + current_u8 & 0b0011_1111}')
+				eprintln('decode: QOI_OP_RUN len=${1 + current_byte & 0b0011_1111}')
 			}
-			for _ in 0 .. 1 + current_u8 & 0b0011_1111 {
+			for _ in 0 .. 1 + current_byte & 0b0011_1111 {
 				$if vqoi_debug ? {
-					eprintln('decode: => $last_pixel')
+					eprintln('decode: => ${last_pixel}')
 				}
 				pixels << last_pixel
 			}

--- a/src/decoder.v
+++ b/src/decoder.v
@@ -7,7 +7,7 @@ pub fn decode(data []u8) !Image {
 	metadata := metadata_from_header(data) or { return err }
 
 	total_pixels := int(metadata.height * metadata.width)
-	mut pixels := [][4]u8{ cap: total_pixels }
+	mut pixels := [][4]u8{cap: total_pixels}
 	mut array := [64][4]u8{}
 	mut offset := 14
 
@@ -78,7 +78,7 @@ pub fn decode(data []u8) !Image {
 		}
 		pixels << new_pixel
 		$if vqoi_debug ? {
-			eprintln('decode: => $new_pixel (${pixels.last()})')
+			eprintln('decode: => ${new_pixel} (${pixels.last()})')
 		}
 		array[color_hash(new_pixel)] = new_pixel
 		last_pixel = new_pixel

--- a/src/decoder.v
+++ b/src/decoder.v
@@ -56,11 +56,11 @@ pub fn decode(data []u8) !Image {
 			$if vqoi_debug ? {
 				eprintln('decode: QOI_OP_LUME')
 			}
-			next_u8 := data[offset + 1]
+			next_byte := data[offset + 1]
 			vg := (current_byte & 0x3f) - 32
-			new_pixel[0] = last_pixel[0] + vg - 8 + (next_u8 >> 4 & 0b0000_1111)
+			new_pixel[0] = last_pixel[0] + vg - 8 + (next_byte >> 4 & 0b0000_1111)
 			new_pixel[1] = last_pixel[1] + vg
-			new_pixel[2] = last_pixel[2] + vg - 8 + (next_u8 & 0b0000_1111)
+			new_pixel[2] = last_pixel[2] + vg - 8 + (next_byte & 0b0000_1111)
 			new_pixel[3] = last_pixel[3]
 			offset += 2
 		} else if current_byte >> 6 == 0b11 { // QOI_OP_RUN

--- a/src/encoder.v
+++ b/src/encoder.v
@@ -1,14 +1,14 @@
 module vqoi
 
 
-pub fn encode(image Image) []byte {
-	mut result := []byte{}
+pub fn encode(image Image) []u8 {
+	mut result := []u8{}
 	result << image.metadata.as_header()
 
-	mut array := [64][4]byte{}
-	mut last_pixel := [byte(0), 0, 0, 255]!
+	mut array := [64][4]u8{}
+	mut last_pixel := [u8(0), 0, 0, 255]!
 
-	mut run := byte(0)
+	mut run := u8(0)
 	for pixel in image.rgba {
 		$if vqoi_debug ? {
 			eprintln('encode: pos: $result.len, pixel: $pixel')
@@ -59,13 +59,13 @@ pub fn encode(image Image) []byte {
 				$if vqoi_debug ? {
 					eprintln('encode: QOI_OP_DIFF, vr: $vr, vg: $vg, vb: $vb')
 				}
-				result << (0b01 << 6 | byte(vr + 2) << 4 | byte(vg + 2) << 2 | byte(vb + 2))
+				result << (0b01 << 6 | u8(vr + 2) << 4 | u8(vg + 2) << 2 | u8(vb + 2))
 			} else if vg_r > -9 && vg_r < 8 && vg > -33 && vg < 32 && vg_b > -9 && vg_b < 8 { // QOI_LUME
 				$if vqoi_debug ? {
 					eprintln('encode: QOI_OP_LUME, vg: $vg, vg_r: $vg_r, vg_b: $vg_b')
 				}
-				result << (0b10 << 6 | byte(vg + 32))
-				result << (byte(vg_r + 8) << 4 | byte(vg_b + 8))
+				result << (0b10 << 6 | u8(vg + 32))
+				result << (u8(vg_r + 8) << 4 | u8(vg_b + 8))
 			} else { // QOI_OP_RGB
 				$if vqoi_debug ? {
 					eprintln('encode: QOI_OP_RGB')
@@ -86,6 +86,6 @@ pub fn encode(image Image) []byte {
 		}
 		result << 0b11 << 6 | (run - 1)
 	}
-	result << [byte(0), 0, 0, 0, 0, 0, 0, 1] // magic ending
+	result << [u8(0), 0, 0, 0, 0, 0, 0, 1] // magic ending
 	return result
 }

--- a/src/encoder.v
+++ b/src/encoder.v
@@ -1,6 +1,5 @@
 module vqoi
 
-
 pub fn encode(image Image) []u8 {
 	mut result := []u8{}
 	result << image.metadata.as_header()
@@ -11,7 +10,7 @@ pub fn encode(image Image) []u8 {
 	mut run := u8(0)
 	for pixel in image.rgba {
 		$if vqoi_debug ? {
-			eprintln('encode: pos: $result.len, pixel: $pixel')
+			eprintln('encode: pos: ${result.len}, pixel: ${pixel}')
 		}
 		// QOI_OP_RUN
 		if pixel == last_pixel {
@@ -19,7 +18,7 @@ pub fn encode(image Image) []u8 {
 			// 62 and 63 are reserved for QOI_OP_RGB and QOI_OP_RGBA
 			if run > 61 {
 				$if vqoi_debug ? {
-					eprintln('encode: QOI_OP_RUN, len=$run (premature restart)')
+					eprintln('encode: QOI_OP_RUN, len=${run} (premature restart)')
 				}
 				result << (0b11 << 6 | (run - 1))
 				run = 0
@@ -27,7 +26,7 @@ pub fn encode(image Image) []u8 {
 			continue
 		} else if run > 0 {
 			$if vqoi_debug ? {
-				eprintln('encode: QOI_OP_RUN, len=$run ')
+				eprintln('encode: QOI_OP_RUN, len=${run} ')
 			}
 			result << (0b11 << 6 | (run - 1))
 			run = 0
@@ -57,12 +56,12 @@ pub fn encode(image Image) []u8 {
 
 			if vr > -3 && vr < 2 && vg > -3 && vg < 2 && vb > -3 && vb < 2 { // QOI_OP_DIFF
 				$if vqoi_debug ? {
-					eprintln('encode: QOI_OP_DIFF, vr: $vr, vg: $vg, vb: $vb')
+					eprintln('encode: QOI_OP_DIFF, vr: ${vr}, vg: ${vg}, vb: ${vb}')
 				}
 				result << (0b01 << 6 | u8(vr + 2) << 4 | u8(vg + 2) << 2 | u8(vb + 2))
 			} else if vg_r > -9 && vg_r < 8 && vg > -33 && vg < 32 && vg_b > -9 && vg_b < 8 { // QOI_LUME
 				$if vqoi_debug ? {
-					eprintln('encode: QOI_OP_LUME, vg: $vg, vg_r: $vg_r, vg_b: $vg_b')
+					eprintln('encode: QOI_OP_LUME, vg: ${vg}, vg_r: ${vg_r}, vg_b: ${vg_b}')
 				}
 				result << (0b10 << 6 | u8(vg + 32))
 				result << (u8(vg_r + 8) << 4 | u8(vg_b + 8))
@@ -82,7 +81,7 @@ pub fn encode(image Image) []u8 {
 
 	if run > 0 {
 		$if vqoi_debug ? {
-			eprintln('encode: QOI_OP_RUN, len=$run (exit)')
+			eprintln('encode: QOI_OP_RUN, len=${run} (exit)')
 		}
 		result << 0b11 << 6 | (run - 1)
 	}

--- a/src/image.v
+++ b/src/image.v
@@ -2,6 +2,6 @@ module vqoi
 
 pub struct Image {
 pub:
-	rgba [][4]byte
+	rgba [][4]u8
 	metadata ImageMetadata
 }

--- a/src/image.v
+++ b/src/image.v
@@ -2,6 +2,6 @@ module vqoi
 
 pub struct Image {
 pub:
-	rgba [][4]u8
+	rgba     [][4]u8
 	metadata ImageMetadata
 }

--- a/src/metadata.v
+++ b/src/metadata.v
@@ -51,7 +51,7 @@ pub fn metadata_from_header(data []u8) !ImageMetadata {
 	match data[13] {
 		0 { colorspace = .srgb }
 		1 { colorspace = .linear }
-		else { return error('only supports colorspaces 0 or 1, not ${colorspace}') }
+		else { return error('only supports colorspaces 0 or 1, not ${data[13]}') }
 	}
 
 	return ImageMetadata{width, height, channels, colorspace} 

--- a/src/metadata.v
+++ b/src/metadata.v
@@ -3,7 +3,7 @@ module vqoi
 import encoding.binary
 
 // "qoif"
-const magic_header = [byte(113), 111, 105, 102]
+const magic_header = [u8(113), 111, 105, 102]
 
 
 pub struct ImageMetadata {
@@ -14,27 +14,27 @@ pub mut:
 	colorspace ColorSpace
 }
 
-pub fn (img ImageMetadata) as_header() []byte {
-	mut data := []byte{}
+pub fn (img ImageMetadata) as_header() []u8 {
+	mut data := []u8{}
 	data << magic_header
 
-	mut temp := []byte{len: 4}
+	mut temp := []u8{len: 4}
 	binary.big_endian_put_u32(mut temp, img.width)
 	data << temp
 	binary.big_endian_put_u32(mut temp, img.height)
 	data << temp
 
-	data << byte(img.channels)
-	data << byte(img.colorspace)
+	data << u8(img.channels)
+	data << u8(img.colorspace)
 
 	return data
 }
 
 
-pub fn metadata_from_header(data []byte) ?ImageMetadata {
+pub fn metadata_from_header(data []u8) !ImageMetadata {
 	for i, value in magic_header {
 		if data[i] != value {
-			return error('image is missing magic header bytes')
+			return error('image is missing magic header u8s')
 		}
 	}
 	width := binary.big_endian_u32(data[4..8])
@@ -50,7 +50,7 @@ pub fn metadata_from_header(data []byte) ?ImageMetadata {
 		return error('only supports colorspaces 0 or 1, not $colorspace')
 	}
 
-	return ImageMetadata{width, height, Channel(channels), ColorSpace(colorspace)}
+	return unsafe { ImageMetadata{width, height, Channel(channels), ColorSpace(colorspace)} }
 }
 
 pub enum Channel {

--- a/src/metadata.v
+++ b/src/metadata.v
@@ -40,17 +40,21 @@ pub fn metadata_from_header(data []u8) !ImageMetadata {
 	width := binary.big_endian_u32(data[4..8])
 	height := binary.big_endian_u32(data[8..12])
 
-	channels := data[12]
-	colorspace := data[13]
+	mut channels := Channel.rgb
+	mut colorspace := ColorSpace.linear
 
-	if channels != 3 && channels != 4 {
-		return error('only supports channels 3 or 4, not ${channels}')
+	match data[12] {
+		3 { channels = .rgb }
+		4 { channels = .rgba }
+		else { return error('only supports channels 3 or 4, not ${data[12]}') }
 	}
-	if colorspace != 0 && colorspace != 1 {
-		return error('only supports colorspaces 0 or 1, not ${colorspace}')
+	match data[13] {
+		0 { colorspace = .srgb }
+		1 { colorspace = .linear }
+		else { return error('only supports colorspaces 0 or 1, not ${colorspace}') }
 	}
 
-	return unsafe { ImageMetadata{width, height, Channel(channels), ColorSpace(colorspace)} }
+	return ImageMetadata{width, height, channels, colorspace} 
 }
 
 pub enum Channel {

--- a/src/metadata.v
+++ b/src/metadata.v
@@ -5,11 +5,10 @@ import encoding.binary
 // "qoif"
 const magic_header = [u8(113), 111, 105, 102]
 
-
 pub struct ImageMetadata {
 pub mut:
-	width  u32
-	height u32
+	width      u32
+	height     u32
 	channels   Channel
 	colorspace ColorSpace
 }
@@ -29,7 +28,6 @@ pub fn (img ImageMetadata) as_header() []u8 {
 
 	return data
 }
-
 
 pub fn metadata_from_header(data []u8) !ImageMetadata {
 	for i, value in magic_header {
@@ -54,7 +52,7 @@ pub fn metadata_from_header(data []u8) !ImageMetadata {
 		else { return error('only supports colorspaces 0 or 1, not ${data[13]}') }
 	}
 
-	return ImageMetadata{width, height, channels, colorspace} 
+	return ImageMetadata{width, height, channels, colorspace}
 }
 
 pub enum Channel {

--- a/src/metadata.v
+++ b/src/metadata.v
@@ -34,7 +34,7 @@ pub fn (img ImageMetadata) as_header() []u8 {
 pub fn metadata_from_header(data []u8) !ImageMetadata {
 	for i, value in magic_header {
 		if data[i] != value {
-			return error('image is missing magic header u8s')
+			return error('image is missing magic header bytes')
 		}
 	}
 	width := binary.big_endian_u32(data[4..8])
@@ -44,10 +44,10 @@ pub fn metadata_from_header(data []u8) !ImageMetadata {
 	colorspace := data[13]
 
 	if channels != 3 && channels != 4 {
-		return error('only supports channels 3 or 4, not $channels')
+		return error('only supports channels 3 or 4, not ${channels}')
 	}
 	if colorspace != 0 && colorspace != 1 {
-		return error('only supports colorspaces 0 or 1, not $colorspace')
+		return error('only supports colorspaces 0 or 1, not ${colorspace}')
 	}
 
 	return unsafe { ImageMetadata{width, height, Channel(channels), ColorSpace(colorspace)} }


### PR DESCRIPTION
Hi! I've found this library a little while back and in preparation for integration with a little GLES renderer I'm working on, I went ahead and made it work with the most recent version of V. Nothing much has changed, pretty much just changing around some of the file organization and changing all the bytes to u8.

With this, downloading through VPM should let users just go `import vqoi` instead of `import vqoi.vqoi`.

Cheers!